### PR TITLE
fix: In runInit, install gobind without @latest

### DIFF
--- a/cmd/gomobile/init.go
+++ b/cmd/gomobile/init.go
@@ -80,7 +80,7 @@ func runInit(cmd *command) error {
 	}()
 
 	// Make sure gobind is up to date.
-	if err := goInstall([]string{"golang.org/x/mobile/cmd/gobind@latest"}, nil); err != nil {
+	if err := goInstall([]string{"golang.org/x/mobile/cmd/gobind"}, nil); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
To "make sure gobind is up to date", runInit calls goInstall with "golang.org/x/mobile/cmd/gobind@latest" . But it shouldn't have "@latest". This instruction can replace the gobind command in the user's $GOPATH/bin with an unexpected version. Also, it is possible that "@latest" has a breaking change with the user's application. It is better to call goInstall without "@latest" so that it will follow the directives in the user's go.mod file.
