### PR TITLE
fix: remove dst folders before trying to create them

### DIFF
--- a/cmd/gomobile/init.go
+++ b/cmd/gomobile/init.go
@@ -251,6 +251,9 @@ func doCopyAll(dst, src string) error {
 		}
 		outpath := filepath.Join(dst, path[prefixLen:])
 		if info.IsDir() {
+			if err := removeAll(outpath); err != nil {
+				return err
+			}
 			return os.Mkdir(outpath, 0755)
 		}
 		in, err := os.Open(path)


### PR DESCRIPTION
When trying to recompile with a cache folder, the `os.Mkdir` function failed because the destination directories already exist.
The solution proposed is to delete the directory before trying to create it.

If we want to ignore that these directories already exist, there are other errors because files exist too. Because this solution become more complex, it preferable to delete the directory before trying to create it.